### PR TITLE
pr: feat: PDBERT 모델을 위한 RealVul 데이터셋 전처리 로직 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,3 @@
 2. `pip install -r requirements.txt && sudo apt install universal-ctags`
 3. .env 파일 생성 및 설정 `GITHUB_TOKEN = {본인 깃헙 토큰 키 값}`
 4. `bash ./dataset_pipeline/run.sh`
-
-* (옵션) pdbert 모델을 위해 데이터셋 전처리(RealVul -> pdbert)가 필요하다면 컨테이너 진입후 다음 `cmd` 실행
-```bash
-python prepare_dataset.py {PROJECT_NAME}
-# PROJECT_NAME: RealVul 데이터셋(.csv) 파일의 프로젝트 명(jasper, Chrome, qemu 등)
-# 이때, Real_Vul 을 인자로 입력할경우 모든 데이터셋을 대상으로 pdbert 데이터셋을 생성합니다.
-```


### PR DESCRIPTION
* PDBERT 모델이 요구하는 데이터셋을 생성하기 위해 https://github.com/MJ-bin/PDBERT 에 prepare_dataset.py 을 추가했습니다.  도커빌드시 git clone 하므로 컨테이너 내부 /PDBERT/ 경로에 자동으로 설치됩니다.

해당 스크립트는 <프로젝트 명>을 인자로 받아서 /PDBERT/data/datasets/extrinsic/vul_detect/realvul 하위의 CSV 파일과 소스코드를 활용하여 train.json, test.json, validate.json 을 생성합니다.