### PR TITLE
fix: pdbert 에서 주어진 bigvul 데이터셋을 활용한 데모학습+테스트 실행 스크립트

### DIFF
--- a/docker/pdbert/test_image.bats
+++ b/docker/pdbert/test_image.bats
@@ -5,49 +5,166 @@ setup_file() {
 }
 
 # -------------------------------------------------------------------
+# Test bats: bigvul 데이터셋에서 샘플을 추출하여 빠른 테스트 수행
+# -------------------------------------------------------------------
 
-@test "1. jasper 데이터셋 생성 for pdbert" {
-    # prepare_dataset.py를 사용하여 jasper 데이터셋 JSON 생성
-    # (tar 압축 해제 + CSV → JSON 변환을 모두 처리)
-    run docker exec pdbert python /PDBERT/prepare_dataset.py jasper
+@test "1. test_bats 데이터셋 생성 (bigvul에서 샘플 추출)" {
+    # bigvul 데이터셋에서 train/validate/test 각각 약 10개씩 랜덤 추출하여 test_bats 폴더 생성
+    run docker exec pdbert bash -c '
+        set -e
+        
+        SRC_DIR="/PDBERT/data/datasets/extrinsic/vul_detect/bigvul"
+        DST_DIR="/PDBERT/data/datasets/extrinsic/vul_detect/test_bats"
+        
+        # 소스 디렉토리 확인
+        if [ ! -d "$SRC_DIR" ]; then
+            echo "[ERROR] Source directory not found: $SRC_DIR"
+            exit 1
+        fi
+        
+        # 대상 디렉토리 생성 (이미 존재하면 삭제 후 재생성)
+        rm -rf "$DST_DIR"
+        mkdir -p "$DST_DIR"
+        
+        echo "[INFO] Creating test_bats dataset from bigvul..."
+        
+        # Python으로 각 JSON 파일에서 랜덤 샘플 추출
+        python3 << EOF
+import json
+import random
+import os
+
+random.seed(42)
+
+src_dir = "$SRC_DIR"
+dst_dir = "$DST_DIR"
+
+for filename in ["train.json", "validate.json", "test.json"]:
+    src_path = os.path.join(src_dir, filename)
+    dst_path = os.path.join(dst_dir, filename)
     
-    # 실행 결과 출력 (항상 표시)
-    echo "# prepare_dataset.py output:" >&3
+    if not os.path.exists(src_path):
+        print(f"[WARN] File not found: {src_path}")
+        continue
+    
+    with open(src_path, "r") as f:
+        data = json.load(f)
+    
+    # train은 10개, validate/test는 5개씩 추출
+    sample_size = 10 if filename == "train.json" else 5
+    sample_size = min(sample_size, len(data))
+    
+    sampled = random.sample(data, sample_size)
+    
+    with open(dst_path, "w") as f:
+        json.dump(sampled, f, indent=4)
+    
+    print(f"[INFO] Created {dst_path}: {sample_size} samples from {len(data)}")
+
+print("[INFO] Done!")
+EOF
+        
+        echo "[INFO] test_bats dataset created successfully"
+    '
+    
+    # 실행 결과 출력
+    echo "# test_bats dataset creation output:" >&3
     echo "$output" >&3
     
-    # 종료 코드 0 (성공) 확인
+    # 에러 시 상세 로그 출력
+    if [ "$status" -ne 0 ]; then
+        echo "[ERROR] Dataset creation failed with status $status" >&3
+        echo "$output" >&3
+    fi
+    
+    # 종료 코드 확인
     [ "$status" -eq 0 ]
     
-    # 출력에서 필수 패턴 매칭
-    [[ "$output" == *"Project: jasper"* ]]
-    [[ "$output" == *"Train:"* ]]
-    [[ "$output" == *"Validate:"* ]]
-    [[ "$output" == *"Test:"* ]]
-    [[ "$output" == *"Done!"* ]]
+    # 패턴 매칭
+    [[ "$output" == *"test_bats dataset created successfully"* ]]
     
-    # JSON 파일 생성 확인
-    run docker exec pdbert test -f /PDBERT/data/datasets/extrinsic/vul_detect/realvul/train.json
+    # 파일 생성 확인
+    run docker exec pdbert test -f /PDBERT/data/datasets/extrinsic/vul_detect/test_bats/train.json
     [ "$status" -eq 0 ]
     
-    run docker exec pdbert test -f /PDBERT/data/datasets/extrinsic/vul_detect/realvul/validate.json
+    run docker exec pdbert test -f /PDBERT/data/datasets/extrinsic/vul_detect/test_bats/validate.json
     [ "$status" -eq 0 ]
     
-    run docker exec pdbert test -f /PDBERT/data/datasets/extrinsic/vul_detect/realvul/test.json
+    run docker exec pdbert test -f /PDBERT/data/datasets/extrinsic/vul_detect/test_bats/test.json
     [ "$status" -eq 0 ]
     
-    echo "# JSON files created successfully" >&3
+    echo "# test_bats JSON files created successfully" >&3
 }
 
 
-@test "2. PDBERT 학습 및 평가 (Jasper 데이터셋)" {
-    # pdbert_realvul.jsonnet은 Dockerfile에서 이미 생성됨
-    run docker exec pdbert bash -c "cd /PDBERT/downstream && python train_eval_from_config.py -config configs/vul_detect/pdbert_realvul.jsonnet -task_name vul_detect/realvul -average binary"
-
-    # 실행 결과 출력 (항상 표시)
-    echo "# PDBERT training output:" >&3
+@test "2. test_bats용 jsonnet 설정 파일 생성" {
+    # pdbert_reveal.jsonnet을 복사하여 test_bats용 설정 파일 생성
+    run docker exec pdbert bash -c '
+        set -e
+        
+        SRC_CONFIG="/PDBERT/downstream/configs/vul_detect/pdbert_reveal.jsonnet"
+        DST_CONFIG="/PDBERT/downstream/configs/vul_detect/pdbert_test_bats.jsonnet"
+        
+        # 소스 설정 파일 확인
+        if [ ! -f "$SRC_CONFIG" ]; then
+            echo "[ERROR] Source config not found: $SRC_CONFIG"
+            exit 1
+        fi
+        
+        # 설정 파일 복사 및 경로 수정
+        cp "$SRC_CONFIG" "$DST_CONFIG"
+        sed -i "s|../data/datasets/extrinsic/vul_detect/reveal/|/PDBERT/data/datasets/extrinsic/vul_detect/test_bats/|g" "$DST_CONFIG"
+        
+        echo "[INFO] Created config: $DST_CONFIG"
+        echo "[INFO] Config file content (first 5 lines):"
+        head -n 5 "$DST_CONFIG"
+    '
+    
+    # 실행 결과 출력
+    echo "# jsonnet config creation output:" >&3
     echo "$output" >&3
     
-    # 종료 코드 0 (성공) 확인
+    # 에러 시 상세 로그 출력
+    if [ "$status" -ne 0 ]; then
+        echo "[ERROR] Config creation failed with status $status" >&3
+        echo "$output" >&3
+    fi
+    
+    # 종료 코드 확인
+    [ "$status" -eq 0 ]
+    
+    # 패턴 매칭
+    [[ "$output" == *"Created config:"* ]]
+    [[ "$output" == *"pdbert_test_bats.jsonnet"* ]]
+    
+    # 설정 파일 존재 확인
+    run docker exec pdbert test -f /PDBERT/downstream/configs/vul_detect/pdbert_test_bats.jsonnet
+    [ "$status" -eq 0 ]
+    
+    # 설정 파일 내용에 test_bats 경로가 포함되어 있는지 확인
+    run docker exec pdbert grep -q "test_bats" /PDBERT/downstream/configs/vul_detect/pdbert_test_bats.jsonnet
+    [ "$status" -eq 0 ]
+    
+    echo "# jsonnet config created and verified successfully" >&3
+}
+
+
+@test "3. PDBERT 학습 및 평가 (test_bats 데이터셋)" {
+    # test_bats 데이터셋으로 모델 학습 및 평가
+    run docker exec pdbert bash -c "cd /PDBERT/downstream && python train_eval_from_config.py -config configs/vul_detect/pdbert_test_bats.jsonnet -task_name vul_detect/test_bats -average binary"
+
+    # 실행 결과 출력
+    echo "# PDBERT training output (test_bats):" >&3
+    echo "$output" >&3
+    
+    # 에러 시 상세 로그 출력
+    if [ "$status" -ne 0 ]; then
+        echo "[ERROR] Training failed with status $status" >&3
+        echo "Full output:" >&3
+        echo "$output" >&3
+    fi
+    
+    # 종료 코드 확인
     [ "$status" -eq 0 ]
     
     # 학습 완료 패턴 확인
@@ -61,5 +178,5 @@ setup_file() {
     [[ "$output" == *"Precision"* ]]
     [[ "$output" == *"Recall"* ]]
     
-    echo "# Training and evaluation completed successfully" >&3
+    echo "# Training and evaluation completed successfully (test_bats)" >&3
 }


### PR DESCRIPTION
### 변경점
1. 사용하는 데이터셋을 **pdbert 에서 주어진 bigvul 로부터 추출**하여 **학습/테스트를 수행**하였습니다(변경전: RealVul 데이터셋을 활용해 학습/테스트).
2. test_image.bats 를 위해 컨테이너 내부에 test 용 디렉토리를 추가하여 별도의 공간을 만들었습니다.

```bash
mjbin@DESKTOP-BQI8RT3:/mnt/d/RealVul_prj/VP-Bench/docker/pdbert$ bats test_image.bats
   Using existing compose container: pdbert
    test_bats dataset creation output: 서 샘플 추출)                                                                1/3
   test_bats JSON files created successfully
 ✓ 1. test_bats 데이터셋 생성 (bigvul에서 샘플 추출)
    jsonnet config creation output: 생성                                                                            2/3
   jsonnet config created and verified successfully
 ✓ 2. test_bats용 jsonnet 설정 파일 생성
    PDBERT training output (test_bats):이터셋)                                                                      3/3
   Training and evaluation completed successfully (test_bats)
 ✓ 3. PDBERT 학습 및 평가 (test_bats 데이터셋)

3 tests, 0 failures

```
> 참고: bats 스크립트 실행을 위해 wsl 을 활용하였습니다.